### PR TITLE
Add examples and return docs

### DIFF
--- a/R/all_generic.R
+++ b/R/all_generic.R
@@ -10,6 +10,12 @@
 #' @param hemi Character string specifying hemisphere ('left' or 'right')
 #'
 #' @return Returns a subset of the atlas containing only the specified ROI
+#'
+#' @examples
+#' \donttest{
+#' atlas <- get_aseg_atlas()
+#' roi <- get_roi(atlas, label = atlas$labels[1])
+#' }
 #' @export
 get_roi <- function(x, label, id, hemi) {
   UseMethod("get_roi")
@@ -29,6 +35,12 @@ get_roi <- function(x, label, id, hemi) {
 #' @param ... Additional arguments passed to methods
 #'
 #' @return Returns the atlas object with mapped values
+#'
+#' @examples
+#' \donttest{
+#' atlas <- get_aseg_atlas()
+#' map_atlas(atlas, rnorm(length(atlas$labels)))
+#' }
 #' @export
 map_atlas <- function(x, vals, thresh, ...) {
   UseMethod("map_atlas")

--- a/R/aseg_subcort.R
+++ b/R/aseg_subcort.R
@@ -31,7 +31,7 @@
 #' }
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load the atlas in native space
 #' aseg <- get_aseg_atlas()
 #'

--- a/R/atlas.R
+++ b/R/atlas.R
@@ -17,6 +17,14 @@
 #'   \item Summary of anatomical structures by hemisphere
 #' }
 #'
+#' @return Invisibly returns the input atlas object
+#'
+#' @examples
+#' \donttest{
+#' atlas <- get_aseg_atlas()
+#' print(atlas)
+#' }
+#'
 #' @importFrom crayon bold green blue red white
 #' @importFrom cli rule symbol
 #' @export
@@ -54,6 +62,7 @@ print.atlas <- function(x, ...) {
   
   # Footer
   cat("\n", cli::rule(col = "cyan", width = 60), "\n", sep="")
+  invisible(x)
 }
 
 #' Create Cache Directory for Atlas Data
@@ -129,7 +138,7 @@ clear_cache <- function() {
 #' }
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load two atlases
 #' atlas1 <- get_aseg_atlas()
 #' atlas2 <- get_aseg_atlas()

--- a/R/atlas_methods.R
+++ b/R/atlas_methods.R
@@ -14,6 +14,12 @@
 #'
 #' @return A data frame with mapped statistics and region information or a
 #'   `ggseg` atlas object when supported.
+#'
+#' @examples
+#' \donttest{
+#' atlas <- get_aseg_atlas()
+#' map_atlas(atlas, rnorm(length(atlas$labels)))
+#' }
 #' @export
 map_atlas.atlas <- function(x, vals, thresh = c(0, 0), pos = FALSE, ...) {
   if (inherits(x, "schaefer")) {
@@ -38,6 +44,15 @@ map_atlas.atlas <- function(x, vals, thresh = c(0, 0), pos = FALSE, ...) {
 #' @param x An atlas object
 #' @param y Unused
 #' @param ... Additional arguments passed to plotting functions
+#'
+#' @return A plot object or visualization produced by the atlas specific
+#'   plotting function
+#'
+#' @examples
+#' \donttest{
+#' atlas <- get_schaefer_atlas(parcels="100", networks="7")
+#' plot(atlas, vals = rnorm(length(atlas$labels)))
+#' }
 #' @export
 plot.atlas <- function(x, y, ...) {
   if (inherits(x, "schaefer")) {

--- a/R/chart.R
+++ b/R/chart.R
@@ -20,7 +20,7 @@
 #' @return An echarts4r visualization object containing the 2x2 grid of brain views
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Basic visualization with uniform coloring
 #' plot_glasser()
 #'

--- a/R/dilate_parcels.R
+++ b/R/dilate_parcels.R
@@ -30,7 +30,7 @@
 #'   voxels in existing parcels.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load an atlas
 #' atlas <- get_aseg_atlas()
 #'

--- a/R/ggschaefer.R
+++ b/R/ggschaefer.R
@@ -13,6 +13,12 @@
 #'
 #' @return A ggseg brain atlas object for visualization
 #'
+#' @examples
+#' \donttest{
+#' atlas <- get_schaefer_atlas(parcels="100", networks="7")
+#' gg_atlas <- get_ggseg_atlas(atlas)
+#' }
+#'
 #' @details
 #' The function extracts the network count and parcel count from the atlas name
 #' and returns the corresponding ggseg-compatible atlas object. Supports Schaefer
@@ -49,6 +55,13 @@ get_ggseg_atlas <- function(atlas) {
 #'   for thresholding. Default: FALSE
 #'
 #' @return A ggseg brain atlas object with mapped values
+#'
+#' @examples
+#' \donttest{
+#' atlas <- get_schaefer_atlas(parcels="100", networks="7")
+#' vals <- rnorm(length(atlas$labels))
+#' mapped <- map_to_schaefer(atlas, vals)
+#' }
 #'
 #' @importFrom assertthat assert_that
 #' @importFrom dplyr mutate left_join filter
@@ -104,7 +117,7 @@ map_to_schaefer <- function(atlas, vals, thresh=c(0,0), pos=FALSE) {
 #'   (if interactive=TRUE) showing the visualization
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load Schaefer atlas
 #' atlas <- get_schaefer_atlas("7networks", 100)
 #'

--- a/R/glasser.R
+++ b/R/glasser.R
@@ -37,7 +37,7 @@
 #' \url{https://github.com/PennBBL/xcpEngine/tree/master/atlas/glasser360}
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load atlas in native space
 #' atlas <- get_glasser_atlas()
 #'
@@ -119,6 +119,13 @@ get_glasser_atlas <- function(outspace=NULL) {
 #'
 #' @return A ggseg brain atlas object with mapped values
 #'
+#' @examples
+#' \donttest{
+#' atlas <- get_glasser_atlas()
+#' vals <- rnorm(length(atlas$labels))
+#' mapped <- map_atlas(atlas, vals)
+#' }
+#'
 #' @import ggsegGlasser
 #' @importFrom ggiraph geom_polygon_interactive
 #' @importFrom dplyr left_join mutate
@@ -165,6 +172,13 @@ map_atlas.glasser <- function(x, vals, thresh=c(0,0), pos=FALSE, ...) {
 #' @param ... Additional arguments passed to methods
 #'
 #' @return A ggiraph interactive plot object
+#'
+#' @examples
+#' \donttest{
+#' atlas <- get_glasser_atlas()
+#' vals <- rnorm(length(atlas$labels))
+#' plot(atlas, vals = vals)
+#' }
 #'
 #' @importFrom tibble tibble
 #' @importFrom magrittr %>%
@@ -221,6 +235,14 @@ plot.glasser <- function(x, y, vals=NULL, thresh=c(0,0), pos=FALSE,
 #' @param x A Glasser atlas object
 #' @param ... Additional arguments passed to print methods
 #'
+#' @return Invisibly returns the input atlas object
+#'
+#' @examples
+#' \donttest{
+#' atlas <- get_glasser_atlas()
+#' print(atlas)
+#' }
+#'
 #' @importFrom crayon bold green blue red white yellow
 #' @importFrom cli rule symbol
 #' @export
@@ -274,7 +296,8 @@ print.glasser <- function(x, ...) {
   
   # Footer
   cat("\n", cli::rule(
-    left = crayon::blue(cli::symbol$info), 
+    left = crayon::blue(cli::symbol$info),
     right = "Use plot() for visualization",
     col = "cyan", width = 65), "\n", sep="")
+  invisible(x)
 }

--- a/R/olsen_mtl.R
+++ b/R/olsen_mtl.R
@@ -31,7 +31,7 @@
 #' Journal of Neuroscience, 33(36), 14107-14111.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load the atlas data
 #' data(olsen_mtl)
 #'
@@ -57,7 +57,7 @@
 #' @return A list with class 'atlas' containing the MTL parcellation
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load in native space
 #' mtl <- get_olsen_mtl()
 #'
@@ -108,7 +108,7 @@ get_olsen_mtl <- function(outspace=NULL) {
 #' }
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Basic hippocampal atlas
 #' hipp <- get_hipp_atlas()
 #'

--- a/R/schaefer.R
+++ b/R/schaefer.R
@@ -47,6 +47,15 @@ getmode <- function(v) {
 #'
 #' @return A resampled NeuroVol object in the new space
 #'
+#' @examples
+#' \donttest{
+#' vol <- neuroim2::read_vol(
+#'   system.file("extdata/atlas_aparc_aseg_prob33.nii.gz", package = "neuroatlas")
+#' )
+#' ns <- neuroim2::NeuroSpace(dim = c(10,10,10), spacing = c(1,1,1))
+#' res <- resample(vol, ns)
+#' }
+#'
 #' @importFrom assertthat assert_that
 #' @importFrom neuroim2 resample searchlight_coords spacing
 #' @export
@@ -247,7 +256,7 @@ schaefer_metainfo <- function(parcels, networks, use_cache=TRUE) {
 #' }
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load 300-parcel atlas with 7 networks
 #' atlas <- get_schaefer_atlas(parcels = "300", networks = "7")
 #'
@@ -354,7 +363,7 @@ get_schaefer_atlas <- function(parcels=c("100","200","300","400","500","600","80
 #' }
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load inflated surface atlas
 #' surf_atlas <- get_schaefer_surfatlas(parcels = "300",
 #'                                     networks = "7",

--- a/R/template_flow.R
+++ b/R/template_flow.R
@@ -44,7 +44,7 @@
 #' @return A NeuroVol object containing the requested template
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Get standard brain-extracted MNI template
 #' mni <- get_template()
 #'
@@ -86,8 +86,13 @@ get_template <- function(name="MNI152NLin2009cAsym", desc="brain", resolution=1,
 #'
 #' @inheritParams get_template
 #' @return A NeuroVol object containing the binary brain mask
+#'
+#' @examples
+#' \donttest{
+#' mask <- get_template_brainmask()
+#' }
 #' @export
-get_template_brainmask <- function(name="MNI152NLin2009cAsym", resolution=1, 
+get_template_brainmask <- function(name="MNI152NLin2009cAsym", resolution=1,
                                   extension=".nii.gz") {
   get_template(name=name, desc="brainmask", suffix="mask", 
               resolution=resolution)
@@ -101,8 +106,13 @@ get_template_brainmask <- function(name="MNI152NLin2009cAsym", resolution=1,
 #' @inheritParams get_template
 #' @param label Character string specifying tissue type ("GM", "WM", or "CSF")
 #' @return A NeuroVol object containing the probability map
+#'
+#' @examples
+#' \donttest{
+#' gm_prob <- get_template_probseg(label = "GM")
+#' }
 #' @export
-get_template_probseg <- function(name="MNI152NLin2009cAsym", label="GM", 
+get_template_probseg <- function(name="MNI152NLin2009cAsym", label="GM",
                                 resolution=1, extension=".nii.gz") {
   get_template(name=name, desc=NULL, label=label, suffix="probseg", 
               resolution=resolution)
@@ -117,6 +127,11 @@ get_template_probseg <- function(name="MNI152NLin2009cAsym", label="GM",
 #' @param parcels Number of parcels (400 default)
 #' @param networks Number of networks (17 default)
 #' @return A NeuroVol object containing the parcellation
+#'
+#' @examples
+#' \donttest{
+#' sch <- get_template_schaefer(parcels = 200, networks = 7)
+#' }
 #' @export
 get_template_schaefer <- function(name="MNI152NLin2009cAsym", resolution=1,
                                  parcels=400, networks=17, extension=".nii.gz") {
@@ -131,6 +146,11 @@ get_template_schaefer <- function(name="MNI152NLin2009cAsym", resolution=1,
 #' Returns a list of all available templates in the Templateflow repository.
 #'
 #' @return A character vector of available template names
+#'
+#' @examples
+#' \donttest{
+#' head(templates())
+#' }
 #' @export
 templates <- function() {
   tflow$api$templates()
@@ -143,8 +163,13 @@ templates <- function() {
 #'
 #' @inheritParams get_template
 #' @return A NeuroVol object containing the head template
+#'
+#' @examples
+#' \donttest{
+#' head_img <- get_template_head()
+#' }
 #' @export
-get_template_head <- function(name="MNI152NLin2009cAsym", resolution=1, 
+get_template_head <- function(name="MNI152NLin2009cAsym", resolution=1,
                             extension=".nii.gz") {
   get_template(name=name, desc="head", suffix="T1w", resolution=resolution)
 }
@@ -156,8 +181,13 @@ get_template_head <- function(name="MNI152NLin2009cAsym", resolution=1,
 #'
 #' @inheritParams get_template
 #' @return A NeuroVol object containing the CSF probability map
+#'
+#' @examples
+#' \donttest{
+#' csf_prob <- get_template_csf()
+#' }
 #' @export
-get_template_csf <- function(name="MNI152NLin2009cAsym", resolution=1, 
+get_template_csf <- function(name="MNI152NLin2009cAsym", resolution=1,
                             extension=".nii.gz") {
   get_template_probseg(name=name, label="CSF", resolution=resolution)
 }
@@ -169,8 +199,13 @@ get_template_csf <- function(name="MNI152NLin2009cAsym", resolution=1,
 #'
 #' @inheritParams get_template
 #' @return A NeuroVol object containing the gray matter probability map
+#'
+#' @examples
+#' \donttest{
+#' gm_prob <- get_template_gm()
+#' }
 #' @export
-get_template_gm <- function(name="MNI152NLin2009cAsym", resolution=1, 
+get_template_gm <- function(name="MNI152NLin2009cAsym", resolution=1,
                            extension=".nii.gz") {
   get_template_probseg(name=name, label="GM", resolution=resolution)
 }
@@ -182,8 +217,13 @@ get_template_gm <- function(name="MNI152NLin2009cAsym", resolution=1,
 #'
 #' @inheritParams get_template
 #' @return A NeuroVol object containing the white matter probability map
+#'
+#' @examples
+#' \donttest{
+#' wm_prob <- get_template_wm()
+#' }
 #' @export
-get_template_wm <- function(name="MNI152NLin2009cAsym", resolution=1, 
+get_template_wm <- function(name="MNI152NLin2009cAsym", resolution=1,
                            extension=".nii.gz") {
   get_template_probseg(name=name, label="WM", resolution=resolution)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,8 +8,23 @@ tflow <<- NULL
   
 }
 
+#' Install TemplateFlow Python Dependencies
+#'
+#' @description
+#' Installs the TemplateFlow and scipy Python packages using reticulate.
+#'
+#' @param method Installation method passed to `reticulate::py_install`.
+#' @param conda Conda environment to use for installation.
+#'
+#' @return Invisibly returns `TRUE` when installation succeeds.
+#'
+#' @examples
+#' \donttest{
+#' install_templateflow()
+#' }
 #' @export
 install_templateflow <- function(method = "auto", conda = "auto") {
   reticulate::py_install("scipy", method = method, conda = conda, pip=TRUE)
   reticulate::py_install("templateflow", method = method, conda = conda, pip=TRUE)
+  invisible(TRUE)
 }


### PR DESCRIPTION
## Summary
- document missing examples and return values for exported functions
- replace `\dontrun{}` with `\donttest{}` across examples
- flesh out install_templateflow documentation

## Testing
- `R` not available so unable to run `devtools::document()`