### PR TITLE
Add atlas merge and reduction tests

### DIFF
--- a/tests/testthat/test-dilation.R
+++ b/tests/testthat/test-dilation.R
@@ -1,4 +1,4 @@
-test_that("dilate_parcels works on Glasser atlas", {
+test_that("dilate_atlas works on Glasser atlas", {
   skip_on_cran()  # Skip on CRAN for demonstration purposes
   
   # Load the Glasser atlas
@@ -8,7 +8,7 @@ test_that("dilate_parcels works on Glasser atlas", {
   # Note: We convert the Glasser atlas volume to a logical mask
   mask <- as.logical(neuroim2::as.dense(gl$atlas)) 
   # Attempt dilation with small parameters just for testing
-  dilated <- dilate_parcels(atlas = gl, mask = mask, radius = 2, maxn = 20)
+  dilated <- dilate_atlas(atlas = gl, mask = mask, radius = 2, maxn = 20)
   
   # Check that the result is a ClusteredNeuroVol
   expect_true(inherits(dilated, "ClusteredNeuroVol"))

--- a/tests/testthat/test-merge-atlases.R
+++ b/tests/testthat/test-merge-atlases.R
@@ -1,0 +1,12 @@
+context("merge_atlases")
+
+test_that("merge_atlases combines ids and preserves dimensions", {
+  skip_on_cran()
+  a1 <- get_aseg_atlas()
+  a2 <- get_aseg_atlas()
+  merged <- merge_atlases(a1, a2)
+
+  expect_true(inherits(merged, "atlas"))
+  expect_equal(length(merged$ids), length(a1$ids) + length(a2$ids))
+  expect_equal(dim(merged$atlas), dim(a1$atlas))
+})

--- a/tests/testthat/test-reduce-atlas.R
+++ b/tests/testthat/test-reduce-atlas.R
@@ -1,0 +1,13 @@
+context("reduce_atlas")
+
+test_that("reduce_atlas computes summary statistics", {
+  skip_on_cran()
+  atl <- get_aseg_atlas()
+  vol <- neuroim2::NeuroVol(array(rnorm(prod(dim(atl$atlas))), dim=dim(atl$atlas)),
+                             space = neuroim2::space(atl$atlas))
+  stats <- reduce_atlas(atl, vol, mean)
+
+  expect_s3_class(stats, "tbl_df")
+  expect_equal(ncol(stats), length(atl$ids))
+  expect_equal(nrow(stats), 1)
+})


### PR DESCRIPTION
## Summary
- fix dilation test to use `dilate_atlas`
- add new tests for `merge_atlases`
- add new tests for `reduce_atlas`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: `R: command not found`)*