### PR TITLE
Improve reduce_atlas docs

### DIFF
--- a/R/all_generic.R
+++ b/R/all_generic.R
@@ -59,13 +59,15 @@ map_atlas <- function(x, vals, thresh, ...) {
 #' This is an S3 generic function.
 #'
 #' @param atlas An atlas object or another object for which a method is defined.
-#' @param data_vol A \code{NeuroVol} (3D) or \code{NeuroVec} (4D) object containing the data
-#'   to be summarized.
+#' @param data_vol A \code{NeuroVol} (3D) or \code{NeuroVec} (4D) with the data to be summarized.
+#'   When a 3D volume is supplied the result contains a single row; 4D inputs yield one
+#'   row per time point.
 #' @param stat_func The function to apply to the data within each ROI (e.g., \code{mean},
 #'   \code{sd}, \code{sum}).
-#' @param ... Additional arguments to be passed to \code{stat_func} or other methods.
+#' @param ... Additional arguments passed to \code{stat_func}.
 #'
-#' @return A \code{tibble} summarizing the data_vol by atlas regions.
+#' @return A \code{tibble} with one column per ROI. For \code{NeuroVec} inputs a
+#'   \code{time} column indexes each volume.
 #' @export
 reduce_atlas <- function(atlas, data_vol, stat_func, ...) {
   UseMethod("reduce_atlas")

--- a/R/atlas.R
+++ b/R/atlas.R
@@ -206,6 +206,13 @@ get_roi.atlas <- function(x, label, id=NULL, hemi=NULL) {
 }
 
 #' @rdname reduce_atlas
+#' @inheritParams reduce_atlas
+#'
+#' When \code{data_vol} is a 3D \code{NeuroVol}, the returned tibble contains a
+#' single row with one column per ROI. If a 4D \code{NeuroVec} is supplied, each
+#' time point is summarised separately and a \code{time} column is added to the
+#' tibble.
+#'
 #' @export
 #' @method reduce_atlas atlas
 reduce_atlas.atlas <- function(atlas, data_vol, stat_func, ...) {

--- a/man/reduce_atlas.Rd
+++ b/man/reduce_atlas.Rd
@@ -12,16 +12,18 @@ reduce_atlas(atlas, data_vol, stat_func, ...)
 \arguments{
 \item{atlas}{An atlas object or another object for which a method is defined.}
 
-\item{data_vol}{A \code{NeuroVol} (3D) or \code{NeuroVec} (4D) object containing the data
-to be summarized.}
+\item{data_vol}{A \code{NeuroVol} (3D) or \code{NeuroVec} (4D) with the data to be summarized.
+When a 3D volume is supplied the result contains a single row; 4D inputs yield one
+row per time point.}
 
 \item{stat_func}{The function to apply to the data within each ROI (e.g., \code{mean},
 \code{sd}, \code{sum}).}
 
-\item{...}{Additional arguments to be passed to \code{stat_func} or other methods.}
+\item{...}{Additional arguments passed to \code{stat_func}.}
 }
 \value{
-A \code{tibble} summarizing the data_vol by atlas regions.
+A \code{tibble} with one column per ROI. For \code{NeuroVec} inputs a \code{time} column
+indexes each volume.
 }
 \description{
 Applies a summary function to data within each ROI defined by an atlas.


### PR DESCRIPTION
## Summary
- clarify expected inputs for `reduce_atlas` generic
- document return structure in the atlas method
- regenerate manual page

## Testing
- `Rscript -e "roxygen2::roxygenize()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e804371c832db58d32711a940139