### PR TITLE
Add atlas volume helper and tests

### DIFF
--- a/R/atlas.R
+++ b/R/atlas.R
@@ -218,22 +218,8 @@ reduce_atlas.atlas <- function(atlas, data_vol, stat_func, ...) {
     stop("'stat_func' must be a function.")
   }
 
-  # --- Determine ROI definition volume from 'atlas' (which is an 'atlas' object) ---
-  # For an 'atlas' class object, the ROI definition is expected in atlas$atlas
-  roi_definition_vol <- NULL
-  if (!is.null(atlas$atlas) && methods::is(atlas$atlas, "NeuroVol")) {
-    roi_definition_vol <- atlas$atlas
-  } else if (!is.null(atlas$data) && methods::is(atlas$data, "NeuroVol")) { 
-    # This handles Glasser-like structures if they are passed directly and are also of class 'atlas'
-    # However, typically for a well-defined 'atlas' object, atlas$atlas is primary.
-    # Consider if Glasser objects should have their own S3 method reduce_atlas.glasser_atlas if structure differs significantly
-    # For now, this provides a fallback if atlas$atlas is not present but atlas$data is.
-    roi_definition_vol <- atlas$data
-  }
-
-  if (is.null(roi_definition_vol)) {
-    stop("Could not determine the ROI definition volume from the input 'atlas' object. Expected a NeuroVol in element 'atlas$atlas' or 'atlas$data'.")
-  }
+  # --- Determine ROI definition volume from 'atlas' ---
+  roi_definition_vol <- .get_atlas_volume(atlas)
 
   # --- Extract data using neuroim2::extract_roi_data ---
   extracted_values <- neuroim2::extract_roi_data(data_vol, roi_definition_vol, fun = stat_func, ...)

--- a/R/atlas_utils.R
+++ b/R/atlas_utils.R
@@ -1,0 +1,28 @@
+#' Internal Helper: Get Atlas Volume
+#'
+#' Retrieves the volume component from an atlas object.
+#'
+#' @param atlas An object of class 'atlas' or similar containing a volume
+#'   definition in either `atlas$atlas` or `atlas$data`.
+#'
+#' @return A `NeuroVol` object used to define ROIs.
+#' @keywords internal
+#' @noRd
+.get_atlas_volume <- function(atlas) {
+  vol <- NULL
+
+  if (!is.null(atlas$atlas) && methods::is(atlas$atlas, "NeuroVol")) {
+    vol <- atlas$atlas
+  } else if (!is.null(atlas$atlas) && methods::is(atlas$atlas, "ClusteredNeuroVol")) {
+    vol <- atlas$atlas
+  } else if (!is.null(atlas$data) && methods::is(atlas$data, "NeuroVol")) {
+    vol <- atlas$data
+  } else if (!is.null(atlas$data) && methods::is(atlas$data, "ClusteredNeuroVol")) {
+    vol <- atlas$data
+  }
+
+  if (is.null(vol)) {
+    stop("Could not determine atlas volume from object")
+  }
+  vol
+}

--- a/R/dilate_parcels.R
+++ b/R/dilate_parcels.R
@@ -96,8 +96,9 @@ dilate_atlas <- function(atlas, mask, radius = 4, maxn = 50) {
     assertthat::assert_that(maxn > 0,
                             msg = "`maxn` must be positive")
 
-    # Convert the atlas to a dense array
-    atlas2 <- neuroim2::as.dense(atlas$atlas)
+    # Convert the atlas volume to a dense array
+    atlas_vol <- .get_atlas_volume(atlas)
+    atlas2 <- neuroim2::as.dense(atlas_vol)
 
     # Identify the indices of labeled voxels and mask voxels
     atlas_idx <- which(atlas2 > 0)
@@ -173,7 +174,7 @@ dilate_atlas <- function(atlas, mask, radius = 4, maxn = 50) {
 
     # Check that we haven't introduced any labels not present in label_map
     unique_labels <- unique(atlas2[atlas2 != 0])
-    missing_labels <- setdiff(unique_labels, unlist(atlas$atlas@label_map))
+    missing_labels <- setdiff(unique_labels, unlist(atlas_vol@label_map))
     if (length(missing_labels) > 0) {
         stop(sprintf(
             "Found labels in dilated atlas that are not in label_map: %s",
@@ -185,7 +186,7 @@ dilate_atlas <- function(atlas, mask, radius = 4, maxn = 50) {
     dilated_vol <- neuroim2::ClusteredNeuroVol(
         mask    = as.logical(atlas2),
         clusters = atlas2[atlas2 != 0],
-        label_map = atlas$atlas@label_map
+        label_map = atlas_vol@label_map
     )
 
     # Now return an atlas object (with the same fields/classes as the input).

--- a/tests/testthat/test-reduce-atlas.R
+++ b/tests/testthat/test-reduce-atlas.R
@@ -11,3 +11,14 @@ test_that("reduce_atlas computes summary statistics", {
   expect_equal(ncol(stats), length(atl$ids))
   expect_equal(nrow(stats), 1)
 })
+
+test_that("reduce_atlas works on Glasser atlas", {
+  skip_on_cran()
+  gl <- get_glasser_atlas()
+  vol <- neuroim2::NeuroVol(array(rnorm(prod(dim(gl$atlas))), dim=dim(gl$atlas)),
+                             space = neuroim2::space(gl$atlas))
+  stats <- reduce_atlas(gl, vol, mean)
+
+  expect_s3_class(stats, "tbl_df")
+  expect_equal(ncol(stats), length(gl$ids))
+})


### PR DESCRIPTION
## Summary
- add `.get_atlas_volume()` utility
- use `.get_atlas_volume()` in `reduce_atlas.atlas` and `dilate_atlas`
- test reduction on Glasser atlas

## Testing
- `R -q -e "devtools::test()"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840e8065190832d888917bae49e1870