### PR TITLE
Ensure volume dimensions match before reducing atlas

### DIFF
--- a/R/atlas.R
+++ b/R/atlas.R
@@ -235,6 +235,11 @@ reduce_atlas.atlas <- function(atlas, data_vol, stat_func, ...) {
     stop("Could not determine the ROI definition volume from the input 'atlas' object. Expected a NeuroVol in element 'atlas$atlas' or 'atlas$data'.")
   }
 
+  # --- Ensure data_vol and ROI definition share dimensions ---
+  if (!all(dim(data_vol) == dim(roi_definition_vol))) {
+    stop("The dimensions of 'data_vol' and the ROI definition volume do not match.")
+  }
+
   # --- Extract data using neuroim2::extract_roi_data ---
   extracted_values <- neuroim2::extract_roi_data(data_vol, roi_definition_vol, fun = stat_func, ...)
 

--- a/tests/testthat/test-reduce-atlas.R
+++ b/tests/testthat/test-reduce-atlas.R
@@ -11,3 +11,13 @@ test_that("reduce_atlas computes summary statistics", {
   expect_equal(ncol(stats), length(atl$ids))
   expect_equal(nrow(stats), 1)
 })
+
+test_that("reduce_atlas errors with mismatched dimensions", {
+  skip_on_cran()
+  atl <- get_aseg_atlas()
+  wrong_dim <- dim(atl$atlas) + c(1, 0, 0)
+  new_space <- neuroim2::NeuroSpace(dim = wrong_dim,
+                                    spacing = neuroim2::spacing(neuroim2::space(atl$atlas)))
+  vol <- neuroim2::NeuroVol(array(0, dim = wrong_dim), space = new_space)
+  expect_error(reduce_atlas(atl, vol, mean), "dimensions")
+})


### PR DESCRIPTION
## Summary
- validate that `data_vol` matches atlas dimensions before ROI extraction
- add regression test for dimension mismatch

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e80b8b88832d9df0a252c91a33c9