### PR TITLE
Fix reduce_atlas column naming

### DIFF
--- a/R/atlas.R
+++ b/R/atlas.R
@@ -238,6 +238,21 @@ reduce_atlas.atlas <- function(atlas, data_vol, stat_func, ...) {
   # --- Extract data using neuroim2::extract_roi_data ---
   extracted_values <- neuroim2::extract_roi_data(data_vol, roi_definition_vol, fun = stat_func, ...)
 
+  label_names <- NULL
+  if (!is.null(atlas$orig_labels)) {
+    label_names <- atlas$orig_labels
+  } else if (!is.null(atlas$labels)) {
+    label_names <- atlas$labels
+  }
+
+  if (!is.null(label_names)) {
+    if (is.vector(extracted_values)) {
+      names(extracted_values) <- label_names
+    } else if (is.matrix(extracted_values)) {
+      colnames(extracted_values) <- label_names
+    }
+  }
+
   # --- Convert to tibble ---
   result_tibble <- NULL
   if (is.vector(extracted_values)) {

--- a/tests/testthat/test-reduce-atlas.R
+++ b/tests/testthat/test-reduce-atlas.R
@@ -10,4 +10,17 @@ test_that("reduce_atlas computes summary statistics", {
   expect_s3_class(stats, "tbl_df")
   expect_equal(ncol(stats), length(atl$ids))
   expect_equal(nrow(stats), 1)
+  expect_equal(colnames(stats), atl$orig_labels)
+})
+
+test_that("reduce_atlas names columns for matrix output", {
+  skip_on_cran()
+  atl <- get_aseg_atlas()
+  arr <- array(rnorm(prod(dim(atl$atlas)) * 2), dim=c(dim(atl$atlas), 2))
+  vec <- neuroim2::NeuroVec(arr, space = neuroim2::space(atl$atlas))
+  stats <- reduce_atlas(atl, vec, mean)
+
+  expect_s3_class(stats, "tbl_df")
+  expect_equal(nrow(stats), 2)
+  expect_equal(colnames(stats), c("time", atl$orig_labels))
 })


### PR DESCRIPTION
## Summary
- name the vector/matrix result from `neuroim2::extract_roi_data`
- propagate those names to the tibble returned by `reduce_atlas`
- test column naming for both vector and matrix outputs

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e8104b50832d9daa5782650fcc03