### PR TITLE
Refresh README with new atlases and analysis features

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -25,12 +25,16 @@ knitr::opts_chunk$set(
 
 ## Features
 
-- **Multiple Atlas Support**: Access Schaefer (100-1000 parcels), Brainnetome (246 regions), Glasser (360 regions), FreeSurfer ASEG, and Olsen MTL atlases
-- **Flexible Resampling**: Transform atlases to different spaces and resolutions
-- **ROI Analysis**: Extract and analyze specific regions of interest with `get_roi()`, `map_atlas()`, and `reduce_atlas()`
-- **Surface & Volume**: Work with both volumetric and surface-based parcellations
-- **TemplateFlow Integration**: Access standardized templates via the Python TemplateFlow API
-- **Visualization**: Integration with the ggseg ecosystem for brain visualization
+- **Many built-in atlases**: Schaefer (100-1000 parcels), Brainnetome (246 regions), Glasser (360 regions), Harvard-Oxford, Julich-Brain, FreeSurfer ASEG, harmonized TemplateFlow/AtlasPack subcortical atlases, Olsen MTL, and probabilistic visual-cortex atlases (Wang 2015, visfAtlas, cytoarchitectonic V1-V5)
+- **Surface & volume**: Work with both volumetric and surface-based parcellations through one consistent interface
+- **Atlas discovery**: Enumerate built-ins with `list_atlases()` and load any of them by name with `get_atlas()`
+- **ROI analysis**: Extract and summarise regions with `get_roi()`, `map_atlas()`, `reduce_atlas()`, and `batch_reduce()`
+- **Atlas operations**: Combine and reshape parcellations with `merge_atlases()`, `filter_atlas()`, `dilate_atlas()`, `atlas_overlap()`, and resampling across spaces/resolutions
+- **Spatial queries**: Look up parcels by world, voxel, or MNI coordinate with `query_point()`, `query_coord()`, and `query_vox()`
+- **Network & graph tools**: `atlas_connectivity()`, `atlas_graph()` / `as_igraph()`, `atlas_hierarchy()`, and `spin_test()` spatial null models
+- **TemplateFlow integration**: Access standardized templates via the Python TemplateFlow API
+- **Visualization**: Publication-quality surface figures with `plot_brain()` / `plot_brain_grid()`, perceptually-optimised ROI palettes, the ggseg ecosystem, and an interactive `cluster_explorer()` Shiny app
+- **Provenance**: Every atlas carries structured space, family, and source metadata (`atlas_ref()`, `atlas_provenance()`)
 
 ## Installation
 
@@ -68,6 +72,16 @@ glasser <- get_glasser_atlas()
 mni_brain <- get_template("MNI152NLin2009cAsym", variant = "brain")
 ```
 
+### Discovering and loading atlases
+
+```{r discover, eval = FALSE}
+# See every built-in atlas
+list_atlases()
+
+# Load any of them by id (with loader-specific arguments)
+schaefer <- get_atlas("schaefer2018", parcels = "100", networks = "7")
+```
+
 ## Palette demos
 
 `neuroatlas` now includes perceptually-optimised palettes for atlas ROIs. For
@@ -99,20 +113,26 @@ ggseg_schaefer(parcels = 200, networks = 7) +
 
 | Atlas | Function | Description |
 |-------|----------|-------------|
-| Schaefer | `get_schaefer_atlas()` | Cortical parcellations (100-1000 regions, 7 or 17 networks) |
+| Schaefer | `get_schaefer_atlas()` | Cortical parcellations (100-1000 regions, 7 or 17 networks); surface via `get_schaefer_surfatlas()` |
 | Brainnetome | `get_brainnetome_atlas()` | 246-region connectional atlas with Yeo network and cytoarchitectonic metadata |
-| Glasser | `get_glasser_atlas()` | 360-region multi-modal cortical parcellation |
-| ASEG | `get_aseg_atlas()` | FreeSurfer subcortical segmentation |
+| Glasser | `get_glasser_atlas()` | 360-region multi-modal cortical parcellation (surface via `glasser_surf()`) |
 | Harvard-Oxford | `get_harvard_oxford_atlas()` | Cortical/subcortical structural atlases via TemplateFlow or FSL |
 | Julich-Brain | `get_julich_brain_atlas()` | FSL Julich-Brain cytoarchitectonic atlas |
+| ASEG | `get_aseg_atlas()` | FreeSurfer subcortical segmentation |
+| Subcortical | `get_subcortical_atlas()` | Harmonized thalamus, cerebellum, and subcortex atlases (AtlasPack/TemplateFlow) |
 | Olsen MTL | `get_olsen_mtl()` | Medial temporal lobe atlas with hippocampal subfields |
+| Wang (2015) | `get_wang_atlas()` | Probabilistic visual topography on `fsaverage` (25 areas/hemi); probability volumes via `get_wang_prob_atlas()` |
+| visfAtlas | `get_visfatlas()` | Probabilistic functional atlas of occipito-temporal visual cortex (33 regions) |
+| Visual V1-V5 | `get_visual_atlas()` | Cytoarchitectonic early visual areas extracted from Julich-Brain |
 
 ## Documentation
 
 - [Getting Started](https://bbuchsbaum.github.io/neuroatlas/articles/neuroatlas-overview.html) - Introduction and basic usage
+- [Atlas Visualization with Optimal Colours](https://bbuchsbaum.github.io/neuroatlas/articles/atlas-visualization.html) - Perceptually-optimised ROI palettes
 - [Surface Panel Figures](https://bbuchsbaum.github.io/neuroatlas/articles/surface-panels.html) - Static panel composition with `plot_brain()` and `plot_brain_grid()`
-- [Working with TemplateFlow](https://bbuchsbaum.github.io/neuroatlas/articles/working-with-templateflow.html) - Template access and management
+- [Surface Templates](https://bbuchsbaum.github.io/neuroatlas/articles/surface-templates.html) - Geometry vs. data on surface meshes
 - [Surface Parcellations](https://bbuchsbaum.github.io/neuroatlas/articles/surface-parcellations.html) - Surface-based atlas operations
+- [Working with TemplateFlow](https://bbuchsbaum.github.io/neuroatlas/articles/working-with-templateflow.html) - Template access and management
 - [Function Reference](https://bbuchsbaum.github.io/neuroatlas/reference/index.html) - Complete API documentation
 
 ## Related Packages

--- a/README.md
+++ b/README.md
@@ -20,19 +20,33 @@ consistent, user-friendly functions.
 
 ## Features
 
-- **Multiple Atlas Support**: Access Schaefer (100-1000 parcels),
-  Brainnetome (246 regions), Glasser (360 regions), FreeSurfer ASEG, and
-  Olsen MTL atlases
-- **Flexible Resampling**: Transform atlases to different spaces and
-  resolutions
-- **ROI Analysis**: Extract and analyze specific regions of interest
-  with `get_roi()`, `map_atlas()`, and `reduce_atlas()`
-- **Surface & Volume**: Work with both volumetric and surface-based
-  parcellations
-- **TemplateFlow Integration**: Access standardized templates via the
+- **Many built-in atlases**: Schaefer (100-1000 parcels), Brainnetome
+  (246 regions), Glasser (360 regions), Harvard-Oxford, Julich-Brain,
+  FreeSurfer ASEG, harmonized TemplateFlow/AtlasPack subcortical atlases,
+  Olsen MTL, and probabilistic visual-cortex atlases (Wang 2015,
+  visfAtlas, cytoarchitectonic V1-V5)
+- **Surface & volume**: Work with both volumetric and surface-based
+  parcellations through one consistent interface
+- **Atlas discovery**: Enumerate built-ins with `list_atlases()` and load
+  any of them by name with `get_atlas()`
+- **ROI analysis**: Extract and summarise regions with `get_roi()`,
+  `map_atlas()`, `reduce_atlas()`, and `batch_reduce()`
+- **Atlas operations**: Combine and reshape parcellations with
+  `merge_atlases()`, `filter_atlas()`, `dilate_atlas()`,
+  `atlas_overlap()`, and resampling across spaces/resolutions
+- **Spatial queries**: Look up parcels by world, voxel, or MNI coordinate
+  with `query_point()`, `query_coord()`, and `query_vox()`
+- **Network & graph tools**: `atlas_connectivity()`, `atlas_graph()` /
+  `as_igraph()`, `atlas_hierarchy()`, and `spin_test()` spatial null
+  models
+- **TemplateFlow integration**: Access standardized templates via the
   Python TemplateFlow API
-- **Visualization**: Integration with the ggseg ecosystem for brain
-  visualization
+- **Visualization**: Publication-quality surface figures with
+  `plot_brain()` / `plot_brain_grid()`, perceptually-optimised ROI
+  palettes, the ggseg ecosystem, and an interactive `cluster_explorer()`
+  Shiny app
+- **Provenance**: Every atlas carries structured space, family, and
+  source metadata (`atlas_ref()`, `atlas_provenance()`)
 
 ## Installation
 
@@ -72,6 +86,16 @@ glasser <- get_glasser_atlas()
 mni_brain <- get_template("MNI152NLin2009cAsym", variant = "brain")
 ```
 
+### Discovering and loading atlases
+
+``` r
+# See every built-in atlas
+list_atlases()
+
+# Load any of them by id (with loader-specific arguments)
+schaefer <- get_atlas("schaefer2018", parcels = "100", networks = "7")
+```
+
 ## Palette demos
 
 `neuroatlas` now includes perceptually-optimised palettes for atlas
@@ -103,28 +127,38 @@ ggseg_schaefer(parcels = 200, networks = 7) +
 
 | Atlas | Function | Description |
 |----|----|----|
-| Schaefer | `get_schaefer_atlas()` | Cortical parcellations (100-1000 regions, 7 or 17 networks) |
+| Schaefer | `get_schaefer_atlas()` | Cortical parcellations (100-1000 regions, 7 or 17 networks); surface via `get_schaefer_surfatlas()` |
 | Brainnetome | `get_brainnetome_atlas()` | 246-region connectional atlas with Yeo network and cytoarchitectonic metadata |
-| Glasser | `get_glasser_atlas()` | 360-region multi-modal cortical parcellation |
-| ASEG | `get_aseg_atlas()` | FreeSurfer subcortical segmentation |
+| Glasser | `get_glasser_atlas()` | 360-region multi-modal cortical parcellation (surface via `glasser_surf()`) |
 | Harvard-Oxford | `get_harvard_oxford_atlas()` | Cortical/subcortical structural atlases via TemplateFlow or FSL |
 | Julich-Brain | `get_julich_brain_atlas()` | FSL Julich-Brain cytoarchitectonic atlas |
+| ASEG | `get_aseg_atlas()` | FreeSurfer subcortical segmentation |
+| Subcortical | `get_subcortical_atlas()` | Harmonized thalamus, cerebellum, and subcortex atlases (AtlasPack/TemplateFlow) |
 | Olsen MTL | `get_olsen_mtl()` | Medial temporal lobe atlas with hippocampal subfields |
+| Wang (2015) | `get_wang_atlas()` | Probabilistic visual topography on `fsaverage` (25 areas/hemi); probability volumes via `get_wang_prob_atlas()` |
+| visfAtlas | `get_visfatlas()` | Probabilistic functional atlas of occipito-temporal visual cortex (33 regions) |
+| Visual V1-V5 | `get_visual_atlas()` | Cytoarchitectonic early visual areas extracted from Julich-Brain |
 
 ## Documentation
 
 - [Getting
   Started](https://bbuchsbaum.github.io/neuroatlas/articles/neuroatlas-overview.html) -
   Introduction and basic usage
+- [Atlas Visualization with Optimal
+  Colours](https://bbuchsbaum.github.io/neuroatlas/articles/atlas-visualization.html) -
+  Perceptually-optimised ROI palettes
 - [Surface Panel
   Figures](https://bbuchsbaum.github.io/neuroatlas/articles/surface-panels.html) -
   Static panel composition with `plot_brain()` and `plot_brain_grid()`
-- [Working with
-  TemplateFlow](https://bbuchsbaum.github.io/neuroatlas/articles/working-with-templateflow.html) -
-  Template access and management
+- [Surface
+  Templates](https://bbuchsbaum.github.io/neuroatlas/articles/surface-templates.html) -
+  Geometry vs. data on surface meshes
 - [Surface
   Parcellations](https://bbuchsbaum.github.io/neuroatlas/articles/surface-parcellations.html) -
   Surface-based atlas operations
+- [Working with
+  TemplateFlow](https://bbuchsbaum.github.io/neuroatlas/articles/working-with-templateflow.html) -
+  Template access and management
 - [Function
   Reference](https://bbuchsbaum.github.io/neuroatlas/reference/index.html) -
   Complete API documentation


### PR DESCRIPTION
- Add visual-cortex atlases (Wang 2015, visfAtlas, cytoarchitectonic
  V1-V5) and harmonized subcortical atlases to the atlas table
- Expand Features to cover atlas discovery, operations, spatial queries,
  network/graph tools, interactive cluster explorer, and provenance
- Add an atlas discovery example (list_atlases() / get_atlas())
- Link the Atlas Visualization and Surface Templates vignettes